### PR TITLE
[chore] キューのインターフェースを見直した

### DIFF
--- a/content/developer/speaker/queue.mdx
+++ b/content/developer/speaker/queue.mdx
@@ -2,83 +2,90 @@
 
 この項目では、読み上げ音声を再生するためのキューの実装を取り扱います。
 
-# インターフェース
+## インターフェース
+
+### TaskQueue
+
+Promiseを直列で実行するキューです。
 
 ```ts
-interface SpakerQueue {
-  private get running(): boolean;
-  private resources: Promise<void>[];
-  private player: AudioPlayer;
-  public add(resource: AudioResource): void;
+interface TaskQueue<T> {
+  private tasks: Promise[];
+  private getTask(data: T): Promise;
+  public add(data: T): void;
   private async run(): void;
+  private taskQueue(): AsyncGenerator<Promise>
+}
+```
+
+### AudioResourcePlayTaskQueue
+
+音声を再生するPromiseを、順番に処理します。
+
+```ts
+interface AudioResourcePlayTaskQueue {
+  private player: AudioPlayer;
+  private queue: TaskQueue<AudioResource>;
+  public add(resource: AudioResource): void;
 }
 
 // TODO: 文法おかしいから正す
 ```
 
-## 初期化
+## TaskQueue
+
+### インスタンス化
+
+`getTask()`の実装をインスタンス化時に与えます。
 
 ```ts
-const queue = new SpeakerQueue(player);
+const queue = new TaskQueue<T>({ getTask(data: T) { return new Promise() } });
 ```
 
-## 音声の追加
+### タスクの追加
 
 `add()`メソッドを使用します。
 
 ```ts
-queue.add(resource);
+queue.add(data);
 ```
 
-### 入出力
-
-- `resource`は`AudioResource`クラスのオブジェクトです。
-- `add()`は何も返却しません。
+- `add()`メソッドを実行すると、`add`イベントが発生します。
 
 #### テスト
 
-- 型情報のみで制約できるため、必要ありません。
+- `add()`メソッドが実行されたとき、`add`イベントが発生することをテストします。
+- `getTask`を注入した`TaskQueue`の`add()`メソッドにテスト用のデータを渡し、以下を確認します。
+  - すべてのPromiseが順番に実行される。
 
-### 挙動
-- キューが他の`AudioResource`を再生中なら、すぐには再生されません。
-- キューが何も再生していないなら、内部で`run()`メソッドが呼び出されます。
-
-#### テスト
-- （現在再生中かどうかは、`running`プロパティで判断します。）
-##### 再生中なら、すぐに再生されない
-- `running`が`true`のとき、`run()`メソッドが**呼び出されない**ことを確認します。
-- また、`resources`に要素が追加されることを、要素数が1つ増加したことを以て確認します。
-##### 再生中でないなら、`run()`メソッドが呼び出される
-- `running`が`false`のとき、`run()`メソッドが呼び出されることを確認します。
-- また、`resources`に要素が追加されることを、要素数が1つ増加したことを以て確認します。
-
-## 音声再生中かどうか
-
-- `running` プロパティから取得できます。
-- `running`は、`resources`の要素数が0であることを示します。
-
-### テスト
-- `resources`を要素が1個の配列にし、`running`が`true`であることを確認します。
-- `resources`を要素が0個の配列にし、`running`が`false`であることを確認します。
-
-## キューの音声を再生する
+### タスクの実行
 
 - `run()`メソッドを実行します。
-- `run()`メソッドは、`resources`プロパティに対して非同期イテレーションを行って、`resources`配列の要素のPromiseを順番に`await`します。
-  - `await`したら、要素を配列から削除します。
+  - インスタンス化時にすぐに実行されます。
 
-### テスト
-- `resources`配列にすぐに`resolve()`するPromiseを追加して、`run()`メソッドを実行し、`resources`配列が空になることを確認します。
+- `run()`メソッドは、`taskQueue`ジェネレータからyieldされたPromiseを順番にawaitします。
 
-## 音声の再生処理
+### タスクの取り出し
 
-- 上の見出しで、`run()`メソッドはPromiseを処理していました。
-- このPromiseは`add()`メソッドで追加されるものです。
+- `taskQueue`ジェネレータで行われます。
+  - `run()`実行時に内部で呼び出されます。
 
-- このPromiseは、`player`に対して、`AudioPlayer.play()`を実行して、`AudioResource.playStream`の`end`イベントを受け取ると`resolve()`します。
+- `taskQueue`ジェネレータは、`tasks`配列の最初の要素を取り出してyieldします。
+- もし配列が空なら、`add`イベントが起こるのを待ちます。
 
-### テスト
-- 単体テストの必要はありません。
+## AudioResourcePlayTaskQueue
 
+### インスタンス化
 
+```ts
+const queue = new AudioResourcePlayTaskQueue(player)
+```
+
+### 音声再生Promise
+
+`AudioResourcePlayTaskQueue.queue.getTask`で作られるPromiseは、以下の方法で音声を再生します。
+
+1. `AudioPlayer.play()`メソッドを呼び出します。
+2. `AudioResource.playStream`に`end`イベントリスナーを登録します。
+3. `end`イベントが発生したら`resolve`します。
 


### PR DESCRIPTION
- AudioResourcePlayTaskQueueがTaskQueueを持つように変更
- runningを消してPromise処理のループがずっと回るように